### PR TITLE
add names to Actors for debugging

### DIFF
--- a/src/Actors/DarkPlayer.ts
+++ b/src/Actors/DarkPlayer.ts
@@ -29,6 +29,7 @@ import { LightPlayer } from "./LightPlayer";
 import { bodyShadowSS, Resources, SFX_VOLUME } from "../resources";
 
 export class DarkPlayer extends Actor {
+  name = "DarkPlayer";
   //properties that change with progression
   //constitution
   currentHP: number = 25;

--- a/src/Actors/Enemy.ts
+++ b/src/Actors/Enemy.ts
@@ -31,6 +31,7 @@ import { actorFlashWhite } from "../Effects/createWhiteMaterial";
 const enemyRNG = new Random(Date.now()); // Random number generator for enemy behavior
 
 export class Enemy extends Actor {
+  name = "Enemy";
   lightGG: GraphicsGroup;
   darkGG: GraphicsGroup;
   currentGraphic: GraphicsGroup;

--- a/src/Actors/LightPlayer.ts
+++ b/src/Actors/LightPlayer.ts
@@ -46,6 +46,7 @@ import {
 import { bodyShadowSS, Resources, SFX_VOLUME } from "../resources";
 
 export class LightPlayer extends Actor {
+  name = "LightPlayer";
   //properties that change with progression
   //constitution
   currentHP: number = 15;

--- a/src/Actors/WeaponActor.ts
+++ b/src/Actors/WeaponActor.ts
@@ -8,6 +8,7 @@ import { Resources, SFX_VOLUME } from "../resources";
 import { DarkPlayer } from "./DarkPlayer";
 
 export class WeaponActor extends Actor {
+  name = "WeaponActor";
   ac: AnimationComponent<"attackLeft" | "attackRight"> | undefined;
   directionfacing: "Left" | "Right" = "Right";
   state: "idle" | "attack" = "attack";

--- a/src/Actors/lightBullet.ts
+++ b/src/Actors/lightBullet.ts
@@ -9,6 +9,7 @@ import { LightPlayer } from "./LightPlayer";
 const BULLET_SPEED = 300; // Speed of the bullet
 
 export class LightBullet extends Actor {
+  name = "LightBullet";
   damage: number;
   owner: LightPlayer;
   UISignal: Signal = new Signal("stateUpdate"); // Signal to update UI

--- a/src/UI/EndOfWaveModal.ts
+++ b/src/UI/EndOfWaveModal.ts
@@ -304,6 +304,7 @@ export class EndOFWaveModal extends ScreenElement {
 }
 
 class ScreenElementFactory extends ScreenElement {
+  name = "ScreenElementFactory";
   constructor(pos: Vector, graphic: Graphic, scale?: Vector) {
     super({
       pos,
@@ -318,6 +319,7 @@ class ScreenElementFactory extends ScreenElement {
 }
 
 class LabelFactory extends Label {
+  name = "LabelFactory";
   constructor(pos: Vector, text: string, makeBig: boolean = false) {
     super({
       pos,
@@ -337,6 +339,7 @@ class LabelFactory extends Label {
 }
 
 class ProgressionButtons extends ScreenElement {
+  name = "ProgressionButtons";
   upGraphic: NineSlice;
   downGraphic: NineSlice;
   icon: Graphic;


### PR DESCRIPTION
Fills in the name field of Actors to make parsing console logs a bit easier.
Instead of "Entity#99", we'll see a name to indicate the actor subject

![CleanShot 2025-04-23 at 19 20 08@2x](https://github.com/user-attachments/assets/3a05230a-5399-40cf-bf79-ae3cba41aca9)
